### PR TITLE
feat: improve window closing with error handling and loading message

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -20,6 +20,7 @@ import { store } from './store'
 import { update } from './update'
 import serve from './utils/serve'
 import { toggleStartUp } from './utils/startup.util'
+import { forceCloseWin } from './utils/try-close-win'
 import { WidgetConfigs } from './widgets/config'
 import { createSettingWindow, createWindow } from './window'
 config()
@@ -234,12 +235,11 @@ async function onAppReady() {
 		y: 0,
 	})
 	await serve(initWin)
-	initWin.once('ready-to-show', async () => {
-		await new Promise((resolve) => setTimeout(resolve, 2000))
-		initWin.destroy()
-	})
 
-	// initWin.hide()
+	initWin.on('ready-to-show', async () => {
+		await new Promise((resolve) => setTimeout(resolve, 2000)) // after 2 seconds
+		forceCloseWin(initWin)
+	})
 
 	nativeTheme.themeSource = store.get('main').theme
 	createTray()

--- a/electron/utils/try-close-win.ts
+++ b/electron/utils/try-close-win.ts
@@ -1,0 +1,22 @@
+import type { BrowserWindow } from 'electron'
+import { userLogger } from '../../shared/logger'
+
+export function forceCloseWin(win: BrowserWindow) {
+	const title = win.getTitle()
+	try {
+		userLogger.info(`Attempting to close ${title}`)
+		win.destroy()
+		userLogger.info(`Successfully closed ${title}`)
+	} catch (error) {
+		userLogger.error(`Failed to close ${title}: ${error}`)
+		if (!win.isDestroyed()) {
+			win.webContents.closeDevTools()
+			win.hide()
+			setImmediate(() => {
+				if (!win.isDestroyed()) {
+					win.close()
+				}
+			})
+		}
+	}
+}

--- a/src/init/main.tsx
+++ b/src/init/main.tsx
@@ -3,7 +3,7 @@ import { useAnalytics } from '../hooks/useAnalytics'
 
 function App() {
 	useAnalytics('startup')
-	return <div></div>
+	return <div>Please wait while the app is loading...</div>
 }
 
 const rootElement = document.getElementById('root')


### PR DESCRIPTION
- Add forceCloseWin utility with graceful error handling and logging
- Replace direct window.destroy() with safer close mechanism
- Change init window event listener from 'once' to 'on'
- Add loading message to init screen for better UX