### PR TITLE
feat(digital-clock): add configurable auto color updates

### DIFF
--- a/electron/store.ts
+++ b/electron/store.ts
@@ -60,6 +60,7 @@ export interface DigitalClockSettingStore {
 	showSecond: boolean
 	showDate: boolean
 	showTimeZone: boolean
+	autoUpdateColor: boolean
 }
 
 export interface ClockSettingStore extends windowSettings {
@@ -155,6 +156,7 @@ const storeDefaults: StoreKey = {
 			showDate: true,
 			showSecond: true,
 			showTimeZone: true,
+			autoUpdateColor: true,
 			timeZone: {
 				label: 'آسیا / تهران',
 				value: 'Asia/Tehran',

--- a/src/clock/digital/index.tsx
+++ b/src/clock/digital/index.tsx
@@ -30,7 +30,11 @@ export function DigitalClock({ digital }: DigitalClockProps) {
 	const seconds = time.getSeconds().toString().padStart(2, '0')
 
 	const isDay = Number(hours) >= 6 && Number(hours) < 18
-	const textColor = isDay ? 'text-content' : 'text-[#536dfe]'
+	const textColor = digital.autoUpdateColor
+		? isDay
+			? 'text-content'
+			: 'text-[#536dfe]'
+		: 'text-content'
 
 	return (
 		<div className="relative flex flex-col items-center w-full h-full">

--- a/src/setting/pages/clock/tabs/digital.tsx
+++ b/src/setting/pages/clock/tabs/digital.tsx
@@ -61,6 +61,31 @@ export function DigitalClockTab({ digital, timezones, setSettingValue }: Prop) {
 				}}
 			/>
 
+			<Checkbox
+				ripple={true}
+				defaultChecked={digital?.autoUpdateColor}
+				onClick={() =>
+					setSettingValue('digital', {
+						autoUpdateColor: !digital.autoUpdateColor,
+					})
+				}
+				label={
+					<div>
+						<Typography
+							variant={'h5'}
+							color="blue-gray"
+							className="dark:text-[#c7c7c7] text-gray-600 text-[13px] font-[Vazir]"
+						>
+							رنگ بندی خودکار{' '}
+							<span className="font-light">(تغییر رنگ در روز و شب)</span>
+						</Typography>
+					</div>
+				}
+				containerProps={{
+					className: 'flex',
+				}}
+			/>
+
 			<div
 				className="flex flex-col w-full gap-2 mt-2 pb-10 font-[Vazir]"
 				dir="rtl"


### PR DESCRIPTION
- Add autoUpdateColor boolean to DigitalClockSettingStore
- Allow users to disable automatic day/night color changes
- Add Persian UI toggle in digital clock settings
- Maintain existing color behavior when auto-update is disabled